### PR TITLE
Fix linter warning: remove unnecessary use

### DIFF
--- a/fhir-bench-orchestrator/src/lib.rs
+++ b/fhir-bench-orchestrator/src/lib.rs
@@ -12,7 +12,6 @@ use crate::test_framework::{FrameworkOperationLog, FrameworkOperationResult, Fra
 use anyhow::{anyhow, Context, Result};
 use chrono::prelude::*;
 use slog::{self, o, Drain};
-use slog_json;
 
 /// Represents the application's context/state.
 pub struct AppState {


### PR DESCRIPTION
Warning was from a newer version of Clippy. Huzzah for CI building against latest Rust!