### PR TITLE
Fix intermittent HAPI errors after launch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,6 +273,7 @@ dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_cmd 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-std 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "erased-serde 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1415,6 +1426,7 @@ dependencies = [
 "checksum async-attributes 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "efd3d156917d94862e779f356c5acae312b08fd3121e792c857d7928c8088423"
 "checksum async-std 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "538ecb01eb64eecd772087e5b6f7540cbc917f047727339a472dafed2185b267"
 "checksum async-task 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0ac2c016b079e771204030951c366db398864f5026f84a44dafb0ff20f02085d"
+"checksum async-trait 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)" = "da71fef07bc806586090247e971229289f64c210a278ee5ae419314eb386b31d"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"

--- a/dev/stories/0006-hapi-startup-wait.md
+++ b/dev/stories/0006-hapi-startup-wait.md
@@ -62,3 +62,7 @@ These failures look like this in the log:
 ```
 
 These errors _seem_ to clear up once HAPI has been running for a little bit.
+
+## Status
+
+This issue appears to be resolved by <https://github.com/karlmdavis/fhir-benchmarks/pull/8>.

--- a/fhir-bench-orchestrator/Cargo.toml
+++ b/fhir-bench-orchestrator/Cargo.toml
@@ -5,7 +5,12 @@ authors = ["Karl M. Davis <karl@justdavis.com>"]
 edition = "2018"
 
 [dependencies]
+
+# Allow async code.
 async-std = { version = "1", features = ["attributes"] }
+async-trait = "0.1"
+
+# Used for making HTTP requests.
 url = "2"
 reqwest = { version = "0.10", features = ["blocking"] }
 

--- a/fhir-bench-orchestrator/src/lib.rs
+++ b/fhir-bench-orchestrator/src/lib.rs
@@ -46,7 +46,7 @@ pub async fn run_bench_orchestrator() -> Result<()> {
 
         // Launch the implementation's server, etc. This will likely take a while.
         let launch_started = Utc::now();
-        let launch_result = server_plugin.launch();
+        let launch_result = server_plugin.launch(&app_state).await;
         let launch_completed = Utc::now();
 
         // Destructure the launch result into success and failure objects, so they have separate ownership.
@@ -72,7 +72,7 @@ pub async fn run_bench_orchestrator() -> Result<()> {
             let server_handle: &dyn ServerHandle = &*server_handle.unwrap();
 
             // Run the tests against the server.
-            let operations = test_framework::run_operations(&app_state, server_handle)?;
+            let operations = test_framework::run_operations(&app_state, server_handle).await?;
             server_result.operations = Some(operations);
 
             // Optionally pause for manual debugging.

--- a/fhir-bench-orchestrator/src/servers/hapi_jpa.rs
+++ b/fhir-bench-orchestrator/src/servers/hapi_jpa.rs
@@ -73,10 +73,7 @@ async fn wait_for_ready(app_state: &AppState, server_handle: &dyn ServerHandle) 
 
         while !ready {
             probe = Some(probe_for_ready(app_state, server_handle).await);
-            ready = match probe.as_ref().expect("probe result missing") {
-                Ok(_) => true,
-                Err(_) => false,
-            };
+            ready = probe.as_ref().expect("probe result missing").is_ok();
         }
 
         probe.expect("probe results missing")

--- a/fhir-bench-orchestrator/src/servers/hapi_jpa.rs
+++ b/fhir-bench-orchestrator/src/servers/hapi_jpa.rs
@@ -1,6 +1,8 @@
 //! TODO
-use super::{ServerHandle, ServerName, ServerPlugin};
+use crate::servers::{ServerHandle, ServerName, ServerPlugin};
+use crate::AppState;
 use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
 use std::process::Command;
 use url::Url;
 
@@ -20,12 +22,13 @@ impl HapiJpaFhirServerPlugin {
     }
 }
 
+#[async_trait]
 impl ServerPlugin for HapiJpaFhirServerPlugin {
     fn server_name(&self) -> &ServerName {
         &self.server_name
     }
 
-    fn launch(&self) -> Result<Box<dyn ServerHandle>> {
+    async fn launch(&self, app_state: &AppState) -> Result<Box<dyn ServerHandle>> {
         /*
          * Build and launch our submodule'd fork of the sample JPA server.
          *
@@ -46,8 +49,54 @@ impl ServerPlugin for HapiJpaFhirServerPlugin {
             )));
         }
 
-        Ok(Box::new(HapiJpaFhirServerHandle {}))
+        // The server containers have now been started, though they're not necessarily ready yet.
+        let server_handle = HapiJpaFhirServerHandle {};
+
+        // Wait (up to a timeout) for the server to be ready.
+        wait_for_ready(app_state, &server_handle).await?;
+
+        Ok(Box::new(server_handle))
     }
+}
+
+/// Checks the specified server repeatedly to see if it is ready, up to a hardcoded timeout.
+///
+/// Parameters:
+/// * `app_state`: the application's [AppState]
+/// * `server_handle`: the server to test
+///
+/// Returns an empty [Result], where an error indicates that the server was not ready.
+async fn wait_for_ready(app_state: &AppState, server_handle: &dyn ServerHandle) -> Result<()> {
+    async_std::future::timeout(std::time::Duration::from_secs(10), async {
+        let mut ready = false;
+        let mut probe = None;
+
+        while !ready {
+            probe = Some(probe_for_ready(app_state, server_handle).await);
+            ready = match probe.as_ref().expect("probe result missing") {
+                Ok(_) => true,
+                Err(_) => false,
+            };
+        }
+
+        probe.expect("probe results missing")
+    })
+    .await?
+}
+
+/// Checks the specified server one time to see if it is ready.
+///
+/// Parameters:
+/// * `app_state`: the application's [AppState]
+/// * `server_handle`: the server to test
+///
+/// Returns an empty [Result], where an error indicates that the server was not ready.
+async fn probe_for_ready(app_state: &AppState, server_handle: &dyn ServerHandle) -> Result<()> {
+    let probe_url = crate::test_framework::metadata::create_metadata_url(server_handle);
+    Ok(
+        crate::test_framework::metadata::run_operation_metadata_iteration(app_state, probe_url)
+            .await?,
+    )
 }
 
 /// Represents a launched instance of the HAPI FHIR JPA server.

--- a/fhir-bench-orchestrator/src/test_framework/metadata.rs
+++ b/fhir-bench-orchestrator/src/test_framework/metadata.rs
@@ -62,7 +62,7 @@ pub async fn run_operation_metadata(
     let mut failures = 0;
     for _ in 0..server_op_log.iterations {
         let iteration_result = run_operation_metadata_iteration(app_state, url.clone()).await;
-        if let Err(_) = iteration_result {
+        if iteration_result.is_err() {
             failures += 1;
         }
     }

--- a/fhir-bench-orchestrator/src/test_framework/metadata.rs
+++ b/fhir-bench-orchestrator/src/test_framework/metadata.rs
@@ -3,13 +3,48 @@
 use crate::servers::ServerHandle;
 use crate::test_framework::ServerOperationLog;
 use crate::AppState;
+use anyhow::{anyhow, Context, Result};
 use chrono::prelude::*;
 use slog::warn;
+use url::Url;
 
 static SERVER_OP_NAME_METADATA: &str = "metadata";
 
+/// Creates the URL to access a server's `/metadata` endpoint.
+pub fn create_metadata_url(server_handle: &dyn ServerHandle) -> Url {
+    server_handle
+        .base_url()
+        .join("metadata")
+        .expect("Error parsing URL.")
+}
+
+/// Runs a single iteration of the `/metadata` operation and verifies its result, logging out any faults that
+/// were found.
+///
+/// Parameters:
+/// * `app_state`: the application's [AppState]
+/// * `url`: the full [Url] to the endpoint to test
+///
+/// Returns an empty [Result], indicating whether or not the operation succeeded or failed.
+pub async fn run_operation_metadata_iteration(app_state: &AppState, url: Url) -> Result<()> {
+    // FIXME probably want to switch to something that supports std_async here
+    let response = reqwest::blocking::get(url.clone())
+        .with_context(|| format!("request for '{}' failed", url))?;
+
+    if !response.status().is_success() {
+        warn!(app_state.logger, "request failed"; "url" => url.as_str(), "status" => response.status().as_str());
+        return Err(anyhow!(
+            "request for '{}' failed with status '{}'",
+            url,
+            response.status()
+        ));
+    }
+    // TODO more checks needed
+    Ok(())
+}
+
 /// Verifies and benchmarks FHIR `/metadata` operations.
-pub fn run_operation_metadata(
+pub async fn run_operation_metadata(
     app_state: &AppState,
     server_handle: &dyn ServerHandle,
 ) -> ServerOperationLog {
@@ -22,27 +57,14 @@ pub fn run_operation_metadata(
         metrics: None,
     };
 
-    let url = server_handle
-        .base_url()
-        .join("metadata")
-        .expect("Error parsing URL.");
+    let url = create_metadata_url(server_handle);
 
     let mut failures = 0;
     for _ in 0..server_op_log.iterations {
-        let response = reqwest::blocking::get(url.clone());
-        match response {
-            Ok(response) => {
-                if !response.status().is_success() {
-                    failures += 1;
-                    warn!(app_state.logger, "request failed"; "url" => url.as_str(), "status" => response.status().as_str());
-                }
-                // TODO more checks needed
-            }
-            Err(err) => {
-                failures += 1;
-                warn!(app_state.logger, "request failed"; "url" => url.as_str(), "err" => format!("{:?}", err));
-            }
-        };
+        let iteration_result = run_operation_metadata_iteration(app_state, url.clone()).await;
+        if let Err(_) = iteration_result {
+            failures += 1;
+        }
     }
 
     server_op_log.failures = Some(failures);

--- a/fhir-bench-orchestrator/src/test_framework/mod.rs
+++ b/fhir-bench-orchestrator/src/test_framework/mod.rs
@@ -6,7 +6,7 @@ use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use slog_derive::SerdeValue;
 
-mod metadata;
+pub mod metadata;
 
 /// Stores the complete set of results from a run of the framework.
 #[derive(Clone, Deserialize, SerdeValue, Serialize)]
@@ -146,13 +146,13 @@ pub struct ServerOperationMetrics {
 }
 
 /// TODO
-pub fn run_operations(
+pub async fn run_operations(
     app_state: &AppState,
     server_handle: &dyn ServerHandle,
 ) -> Result<Vec<ServerOperationLog>> {
     let mut results = vec![];
 
-    results.push(metadata::run_operation_metadata(app_state, server_handle));
+    results.push(metadata::run_operation_metadata(app_state, server_handle).await);
 
     Ok(results)
 }


### PR DESCRIPTION
Resolves the intermittent errors that were occurring after HAPI launched. They were simply due to Docker Compose not waiting for containers to be _ready_, and instead returning right after containers were _started_. The changes here now probe HAPI after launch and wait for it be actually become ready.

This change includes a couple of related refactorings:

1. Abstracted the `/metadata` query support a bit, so that it could be reused to verify server readiness at launch.
2. Marked a number of methods `async`, so that `std_async::future::timeout` could be used in the launch readiness probing.
