### PR TITLE
Collect latency performance data for ops.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,11 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "assert_cmd"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +331,14 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "crc32fast"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,10 +495,13 @@ dependencies = [
  "async-h1 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-std 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "erased-serde 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hdrhistogram 7.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "http-types 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "json 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -503,6 +519,17 @@ dependencies = [
  "slog_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miniz_oxide 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -717,6 +744,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdrhistogram"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 5.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,6 +937,18 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "lexical-core"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,6 +1060,16 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lexical-core 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1556,6 +1618,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "stdweb"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2007,6 +2074,7 @@ dependencies = [
 "checksum aho-corasick 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)" = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
 "checksum anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)" = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
 "checksum arc-swap 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
+"checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 "checksum assert_cmd 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c88b9ca26f9c16ec830350d309397e74ee9abdfd8eb1f71cb6ecc71a3fc818da"
 "checksum async-attributes 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "efd3d156917d94862e779f356c5acae312b08fd3121e792c857d7928c8088423"
 "checksum async-channel 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43de69555a39d52918e2bc33a408d3c0a86c829b212d898f4ca25d21a6387478"
@@ -2036,6 +2104,7 @@ dependencies = [
 "checksum core-foundation 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
 "checksum core-foundation-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 "checksum cpuid-bool 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+"checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
 "checksum crossbeam-channel 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "09ee0cc8804d5393478d743b035099520087a5186f3b93fa58cec08fa62407b6"
 "checksum crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
@@ -2055,6 +2124,7 @@ dependencies = [
 "checksum error-chain 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
 "checksum event-listener 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "68082183f458867ce7cddea16d4df4443c1537112c0c09c450dedc09daf5c719"
 "checksum fastrand 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "36a9cb09840f81cd211e435d00a4e487edd263dc3c8ff815c32dd76ad668ebed"
+"checksum flate2 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "68c90b0fc46cf89d227cc78b40e494ff81287a92dd07631e5af0d06fe3cf885e"
 "checksum fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
@@ -2078,6 +2148,7 @@ dependencies = [
 "checksum gloo-timers 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
 "checksum h2 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
 "checksum hashbrown 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "34f595585f103464d8d2f6e9864682d74c1601fed5e07d62b1c9058dba8246fb"
+"checksum hdrhistogram 7.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c22708574c44e924720c5b3a116326c688e6d532f438c77c007ec8768644f9"
 "checksum hermit-abi 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
 "checksum hkdf 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fe1149865383e4526a43aee8495f9a325f0b806c63ce6427d06336a590abbbc9"
 "checksum hmac 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
@@ -2098,6 +2169,7 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum kv-log-macro 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+"checksum lexical-core 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
 "checksum libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
 "checksum log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
@@ -2111,6 +2183,7 @@ dependencies = [
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
 "checksum net2 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)" = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
+"checksum nom 5.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 "checksum num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 "checksum num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 "checksum num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
@@ -2176,6 +2249,7 @@ dependencies = [
 "checksum socket2 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
 "checksum stable_deref_trait 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 "checksum standback 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b0437cfb83762844799a60e1e3b489d5ceb6a650fbacb86437badc1b6d87b246"
+"checksum static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 "checksum stdweb 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
 "checksum stdweb-derive 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 "checksum stdweb-internal-macros 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"

--- a/fhir-bench-orchestrator/Cargo.toml
+++ b/fhir-bench-orchestrator/Cargo.toml
@@ -49,5 +49,10 @@ chrono = { version = "0.4", features = ["serde"] }
 regex = "1"
 lazy_static = "1"
 
+# Calculate and model performance metrics.
+hdrhistogram = "7"
+base64 = "0.12"
+flate2 = "1.0"
+
 # Used in integration tests, to run binaries and verify results.
 assert_cmd = "1"

--- a/fhir-bench-orchestrator/src/sample_data.rs
+++ b/fhir-bench-orchestrator/src/sample_data.rs
@@ -3,7 +3,7 @@
 use crate::config::AppConfig;
 use anyhow::{anyhow, Context, Result};
 use serde_json::json;
-use slog::{trace, Logger};
+use slog::{info, Logger};
 use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
@@ -98,7 +98,7 @@ pub fn generate_data(logger: &Logger, config: &AppConfig) -> Result<SampleData> 
     /*
      * Build and run the Docker-ized version of Synthea.
      */
-    trace!(logger, "Sample data: generating...");
+    info!(logger, "Sample data: generating...");
     let synthea_bin: PathBuf = synthea_dir.join("generate-synthetic-data.sh");
     if !synthea_bin.is_file() {
         return Err(anyhow!(format!("unable to read file: '{:?}'", synthea_bin)));
@@ -116,7 +116,7 @@ pub fn generate_data(logger: &Logger, config: &AppConfig) -> Result<SampleData> 
             String::from_utf8_lossy(&synthea_process.stderr).into()
         )));
     }
-    trace!(logger, "Sample data: generated.");
+    info!(logger, "Sample data: generated.");
 
     // Write out the config that was used to generate the data.
     let config_file = File::create(&config_path).with_context(|| {

--- a/fhir-bench-orchestrator/src/util/histogram_hgrm_export.rs
+++ b/fhir-bench-orchestrator/src/util/histogram_hgrm_export.rs
@@ -1,0 +1,114 @@
+//! Exports [Histogram]s to the "Histogram Percentiles Text Export" `.hgrm` format, which looks
+//! like:
+//!
+//! ```text
+//!     Value   Percentile   TotalCount 1/(1-Percentile)
+//!
+//!     0.016     0.000000            1         1.00
+//!     0.980     0.100000        47530         1.11
+//! ...
+//!  9428.991     1.000000       475109          inf
+//!     #[Mean    =       25.048, StdDeviation   =      120.097]
+//!     #[Max     =     9420.800, Total count    =       475109]
+//!     #[Buckets =           27, SubBuckets     =         2048]
+//! ```
+
+use anyhow::Result;
+use hdrhistogram::Histogram;
+use std::fmt::Display;
+
+/// The scaling ratio to apply to values on output.
+///
+/// I'm not really sure what this value is, honestly, but I see this value used for it here:
+/// <https://github.com/wayfair-tremor/tremor-runtime/blob/main/src/offramp/blackhole.rs#L105>
+/// (as referenced on
+/// <https://github.com/HdrHistogram/HdrHistogram/issues/170#issuecomment-673414548>).
+const OUTPUT_VALUE_UNIT_SCALING_RATIO: usize = 5;
+
+/// The number of reporting points per exponentially decreasing half-distance.
+///
+/// This appears to be the default in the Java version of HDR Histogram's command line application:
+/// <https://github.com/HdrHistogram/HdrHistogram/blob/0cedc733914117da7ad803e03254b9183e7a740e/src/main/java/org/HdrHistogram/HistogramLogProcessor.java#L77>.
+const PERCENTILE_TICKS_PER_HALF_DISTANCE: u32 = 5;
+
+/// Output histogram data in a format similar to the Java impl's
+/// `AbstractHistogram#outputPercentileDistribution`, but gzip'd and Base64-encoded.
+pub fn export_to_hgrm_gzip(histogram: &Histogram<u64>) -> Result<String> {
+    let mut export: String = String::new();
+    export.push_str(&format!(
+        "{:>12} {:>OUTPUT_VALUE_UNIT_SCALING_RATIO$} {:>10} {:>14}\n\n",
+        "Value",
+        "Percentile",
+        "TotalCount",
+        "1/(1-Percentile)",
+        OUTPUT_VALUE_UNIT_SCALING_RATIO = OUTPUT_VALUE_UNIT_SCALING_RATIO + 2 // + 2 from leading "0." for numbers
+    ));
+    let mut sum = 0;
+    for v in histogram.iter_quantiles(PERCENTILE_TICKS_PER_HALF_DISTANCE) {
+        sum += v.count_since_last_iteration();
+        if v.quantile_iterated_to() < 1.0 {
+            export.push_str(&format!(
+                "{:12} {:1.*} {:10} {:14.2}\n",
+                v.value_iterated_to(),
+                OUTPUT_VALUE_UNIT_SCALING_RATIO,
+                v.quantile_iterated_to(),
+                sum,
+                1_f64 / (1_f64 - v.quantile_iterated_to())
+            ));
+        } else {
+            export.push_str(&format!(
+                "{:12} {:1.*} {:10} {:>14}\n",
+                v.value_iterated_to(),
+                OUTPUT_VALUE_UNIT_SCALING_RATIO,
+                v.quantile_iterated_to(),
+                sum,
+                "∞"
+            ));
+        }
+    }
+
+    fn format_extra_data<T1: Display, T2: Display>(
+        label1: &str,
+        data1: T1,
+        label2: &str,
+        data2: T2,
+    ) -> String {
+        format!(
+            "#[{:10} = {:12.2}, {:14} = {:12.2}]\n",
+            label1, data1, label2, data2
+        )
+    }
+
+    export.push_str(&format_extra_data(
+        "Mean",
+        histogram.mean(),
+        "StdDeviation",
+        histogram.stdev(),
+    ));
+    export.push_str(&format_extra_data(
+        "Max",
+        histogram.max(),
+        "Total count",
+        histogram.len(),
+    ));
+    export.push_str(&format_extra_data(
+        "Buckets",
+        histogram.buckets(),
+        "SubBuckets",
+        histogram.distinct_values(),
+    ));
+
+    /*
+     * Aesthetically, having a giant blob of escaped text in the output annoys me (which is silly,
+     * I know, but it does). Let's clean that up a bit by compressing it and Base64 encoding it.
+     */
+    let export = {
+        use std::io::Write;
+        let mut zipper = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        zipper.write_all(export.as_bytes())?;
+        let zipped_export: Vec<u8> = zipper.finish()?;
+        base64::encode(&zipped_export)
+    };
+
+    Ok(export)
+}

--- a/fhir-bench-orchestrator/src/util/mod.rs
+++ b/fhir-bench-orchestrator/src/util/mod.rs
@@ -1,2 +1,4 @@
+pub mod histogram_hgrm_export;
 pub mod serde_duration_iso8601;
 pub mod serde_duration_millis;
+pub mod serde_histogram;

--- a/fhir-bench-orchestrator/src/util/serde_histogram.rs
+++ b/fhir-bench-orchestrator/src/util/serde_histogram.rs
@@ -1,0 +1,106 @@
+//! A Serde serializer/deserializer for [Histogram] instances that uses the histogram library's
+//! "HistoBlob" serialization format.
+
+use hdrhistogram::serialization::{
+    Deserializer as HistogramDeserializer, Serializer as HistogramSerializer,
+    V2DeflateSerializer as HistogramSerializerImpl,
+};
+use hdrhistogram::Histogram;
+use serde::{self, Deserialize, Deserializer, Serializer};
+
+/// Converts [Histogram] instances to the histogram library's "HistoBlob" serialization format,
+/// for use in JSON.
+///
+/// Parameters:
+/// * `histogram`: the [Histogram] instance to be serialized
+/// * `serializer`: the Serde [Serializer] to use
+///
+/// Returns the [Serializer] result.
+pub fn serialize<S>(histogram: &Histogram<u64>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut bytes = Vec::new();
+    HistogramSerializerImpl::new()
+        .serialize(histogram, &mut bytes)
+        .map_err(|err| serde::ser::Error::custom(format!("{}", err)))?;
+    let bytes_base64 = base64::encode(bytes);
+
+    serializer.serialize_str(&bytes_base64)
+}
+
+/// Converts "HistoBlob" JSON strings back to [Histogram] instances.
+///
+/// Parameters:
+/// * `deserializer`: the Serde [Deserializer] to use
+///
+/// Returns the deserialized [Histogram].
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Histogram<u64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let bytes_base64 = String::deserialize(deserializer)?;
+    let bytes: Vec<u8> = match base64::decode(bytes_base64) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            return Err(serde::de::Error::custom(format!("{}", err)));
+        }
+    };
+    let mut bytes_reader = std::io::Cursor::new(&bytes);
+
+    let mut deserializer = HistogramDeserializer::new();
+    match deserializer.deserialize(&mut bytes_reader) {
+        Ok(histogram) => Ok(histogram),
+        Err(err) => Err(serde::de::Error::custom(format!("{}", err))),
+    }
+}
+
+/// Unit tests for the [Duration] serializer & deserialzer.
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use hdrhistogram::Histogram;
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
+
+    /// Just used to test Serde against.
+    #[derive(Deserialize, Serialize)]
+    struct DurationStruct {
+        #[serde(with = "super")]
+        histogram: Histogram<u64>,
+    }
+
+    /// Verifies that [Duration] values serialize as expected.
+    #[test]
+    fn serialize() -> Result<()> {
+        let expected = json!({
+            "histogram": "HISTFAAAABx4nJNpmSzMwMDAxAABzFCaEUoz2X+AsQA/awKA",
+        });
+        let expected = serde_json::to_string(&expected).unwrap();
+        let mut actual = DurationStruct {
+            histogram: Histogram::<u64>::new(3)?,
+        };
+        actual.histogram.record(1)?;
+        let actual = serde_json::to_string(&actual).unwrap();
+        assert_eq!(expected, actual);
+
+        Ok(())
+    }
+
+    /// Verifies that [Duration] values deserialize as expected.
+    #[test]
+    fn deserialize() -> Result<()> {
+        let mut expected = DurationStruct {
+            histogram: Histogram::<u64>::new(3)?,
+        };
+        expected.histogram.record(1)?;
+        let actual = json!({
+            "histogram": "HISTFAAAABx4nJNpmSzMwMDAxAABzFCaEUoz2X+AsQA/awKA",
+        });
+        let actual = serde_json::to_string(&actual).unwrap();
+        let actual: DurationStruct = serde_json::from_str(&actual).unwrap();
+        assert_eq!(expected.histogram, actual.histogram);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
The latency data is collected via the `hdrhistogram` crate, and then represented a few different ways in the JSON: with specific percentiles, as a "HistoBlob" (serialized `Histogram` struct), and as an embedded `.hgram` file. This latter format is suitable for graphing via <http://hdrhistogram.github.com/HdrHistogram/plotFiles.html> and other plotting tools.

As part of this effort, the operations' resturn data and error handling was significantly reworked. The state of each operation is now tracked via a state machine, which is both more robust and also just neat.

One downside of all this, though, is that code maintainability and readability is really starting to suffer. The overall "run an operation" code is getting pretty hoary, and has a lot (too much copy-pasting). This is mostly on purpose, though: I don't want to build out abstractions for that until I've got one or two more operations implemented, so that I can ensure I'm building the **right** abstractions.
