### PR TITLE
Update to HAPI 5.1 (to fix broken build)

### DIFF
--- a/fhir-bench-orchestrator/src/servers/hapi_jpa.rs
+++ b/fhir-bench-orchestrator/src/servers/hapi_jpa.rs
@@ -64,7 +64,7 @@ impl ServerPlugin for HapiJpaFhirServerPlugin {
                 server_handle.emit_logs_info(&app_state.logger);
                 Err(err)
             }
-            Ok(_) => Ok(Box::new(server_handle))
+            Ok(_) => Ok(Box::new(server_handle)),
         }
     }
 }

--- a/fhir-bench-orchestrator/src/servers/mod.rs
+++ b/fhir-bench-orchestrator/src/servers/mod.rs
@@ -41,6 +41,13 @@ pub trait ServerHandle: Sync {
     /// Return the base URL for the running FHIR server, e.g. `http://localhost:8080/foo/`.
     fn base_url(&self) -> Url;
 
+    /// Write the full log content from the running FHIR server and its dependencies to the
+    /// specified [slog::Logger] at the info level.
+    ///
+    /// Note: This method should not panic. If unable to retrieve the logs, a warning about that
+    /// failure should be logged, instead.
+    fn emit_logs_info(&self, logger: &slog::Logger);
+
     /// TODO
     fn shutdown(&self) -> Result<()>;
 }

--- a/fhir-bench-orchestrator/tests/basics.rs
+++ b/fhir-bench-orchestrator/tests/basics.rs
@@ -21,6 +21,7 @@ fn benchmark_small() {
         .env(ENV_KEY_ITERATIONS, "2")
         .env(ENV_KEY_CONCURRENCY_LEVELS, "1,2")
         .env(ENV_KEY_POPULATION_SIZE, "10")
+        .timeout(std::time::Duration::from_secs(60 * 5))
         .unwrap();
 
     // We want to validate the output from STDOUT and STDERR, so we capture them to `str`s, here.


### PR DESCRIPTION
It looks like HAPI yanked their earlier Docker tags, which broke the build. This fixes that.

In addition, it attempts to make problems like this one easier to diagnose in the future.
