### PR TITLE
Fix Synthea Docker errors and add debugging.

### DIFF
--- a/fhir-bench-orchestrator/src/errors.rs
+++ b/fhir-bench-orchestrator/src/errors.rs
@@ -8,8 +8,8 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum AppError {
     /// Represents an error caused by a child process exiting abnormally.
-    #[error("child process exited with code '{0}' and this message: '{1}'")]
-    ChildProcessFailure(std::process::ExitStatus, String),
+    #[error("child process exited with code '{0}', this message: '{1}, this STDOUT: '{2}', and this STDERR: '{3}")]
+    ChildProcessFailure(std::process::ExitStatus, String, String, String),
 
     /// Represents an error caused by an attempt to lookup an unknown server.
     #[error("unknown server '{0}'")]

--- a/fhir-bench-orchestrator/src/lib.rs
+++ b/fhir-bench-orchestrator/src/lib.rs
@@ -177,6 +177,8 @@ fn verify_prereqs() -> Result<()> {
         return Err(anyhow!(crate::errors::AppError::ChildProcessFailure(
             docker_compose_output.status,
             "Missing pre-req: docker-compose.".to_owned(),
+            String::from_utf8_lossy(&docker_compose_output.stdout).into(),
+            String::from_utf8_lossy(&docker_compose_output.stderr).into()
         )));
     }
 

--- a/fhir-bench-orchestrator/src/sample_data.rs
+++ b/fhir-bench-orchestrator/src/sample_data.rs
@@ -111,6 +111,8 @@ pub fn generate_data(logger: &Logger, config: &AppConfig) -> Result<SampleData> 
     if !synthea_process.status.success() {
         return Err(anyhow!(crate::errors::AppError::ChildProcessFailure(
             synthea_process.status,
+            "Synthea process for sample data generation failed.".into(),
+            String::from_utf8_lossy(&synthea_process.stdout).into(),
             String::from_utf8_lossy(&synthea_process.stderr).into()
         )));
     }

--- a/fhir-bench-orchestrator/src/servers/hapi_jpa.rs
+++ b/fhir-bench-orchestrator/src/servers/hapi_jpa.rs
@@ -52,6 +52,8 @@ impl ServerPlugin for HapiJpaFhirServerPlugin {
             return Err(anyhow!(crate::errors::AppError::ChildProcessFailure(
                 docker_up_output.status,
                 "Failed to launch HAPI FHIR JPA Server via docker-compose.".to_owned(),
+                String::from_utf8_lossy(&docker_up_output.stdout).into(),
+                String::from_utf8_lossy(&docker_up_output.stderr).into()
             )));
         }
 
@@ -155,6 +157,8 @@ impl ServerHandle for HapiJpaFhirServerHandle {
             return Err(anyhow!(crate::errors::AppError::ChildProcessFailure(
                 docker_down_output.status,
                 "Failed to shutdown HAPI FHIR JPA Server via docker-compose.".to_owned(),
+                String::from_utf8_lossy(&docker_down_output.stdout).into(),
+                String::from_utf8_lossy(&docker_down_output.stderr).into()
             )));
         }
 

--- a/synthetic-data/Dockerfile.synthea
+++ b/synthetic-data/Dockerfile.synthea
@@ -2,7 +2,7 @@
 FROM openjdk:8-alpine
 
 # Install pre-reqs.
-RUN apk add --no-cache wget
+RUN apk add --no-cache wget bash
 
 # Configure directories.
 RUN mkdir /synthea \
@@ -10,36 +10,14 @@ RUN mkdir /synthea \
   && mkdir /synthea/target
 WORKDIR /synthea/bin
 
-# Configure user & permissions.
-ARG UID
-ARG GID
-ENV USER=synthea
-RUN \
-  addgroup \
-    --gid "$GID" \
-    "$USER" \
-  && \
-  adduser \
-    --disabled-password \
-    --gecos "" \
-    --ingroup "$USER" \
-    --no-create-home \
-    --uid "$UID" \
-    "$USER"
-RUN \
-  chown -R synthea:synthea /synthea \
-  && \
-  chmod -R o+r /synthea
-USER "$USER"
-
 # Download the Synthea binary distribution. The Synthea CLI builds aren't really versioned, as such; they're
 # published by committing a new cut of the same filename to the repository's `gh-pages` branch. To ensure
 # stability, we grab a specific commit of that branch. A bit hacky, but it works.
-RUN \
-  wget -q https://github.com/synthetichealth/synthea/raw/1d8cdbbf0f02e3f10c00460aa28b59f0495d58cc/build/libs/synthea-with-dependencies.jar
-RUN \
-  chmod u+r,g+r,o+r synthea-with-dependencies.jar
-WORKDIR /synthea/target
+RUN wget -q https://github.com/synthetichealth/synthea/raw/1d8cdbbf0f02e3f10c00460aa28b59f0495d58cc/build/libs/synthea-with-dependencies.jar
+
+# Configure permissions.
+RUN chmod -R u+r,g+r,o+r /synthea
 
 # Run the Synthea CLI binary (user-specified args will be appended to those here).
+WORKDIR /synthea/target
 ENTRYPOINT ["java", "-jar", "/synthea/bin/synthea-with-dependencies.jar", "--exporter.baseDirectory", "/synthea/target/"]

--- a/synthetic-data/generate-synthetic-data.sh
+++ b/synthetic-data/generate-synthetic-data.sh
@@ -36,11 +36,18 @@ if [[ -z "${populationSize}" ]]; then >&2 echo 'The -p option for desired popula
 export DOCKER_BUILDKIT=1
 
 # Build the Docker image for Synthea.
-docker build --file ./Dockerfile.synthea --build-arg UID="$(id -u)" --build-arg GID="$(id -g)" -t "${IMAGE_TAG}" --cache-from docker.pkg.github.com/karlmdavis/fhir-benchmarks/synthea --build-arg BUILDKIT_INLINE_CACHE=1 .
+docker build --file ./Dockerfile.synthea -t "${IMAGE_TAG}" --cache-from docker.pkg.github.com/karlmdavis/fhir-benchmarks/synthea --build-arg BUILDKIT_INLINE_CACHE=1 .
 
 # Run Synthea, with the specified options.
 target="$(pwd)/target"
 if [[ ! -d "${target}" ]]; then mkdir "${target}"; fi
+docker run \
+  --rm \
+  --mount source="${target}",target="/synthea/target/",type=bind \
+  --user "$(id -u)" \
+  --entrypoint '/bin/bash' \
+  "${IMAGE_TAG}" \
+  -x -c 'id && ls -lan / && ls -lan /synthea'
 docker run \
   --rm \
   --mount source="${target}",target="/synthea/target/",type=bind \


### PR DESCRIPTION
The build user stuff appears to have been causing the intermittent GitHub Actions errors: images would be built for one UID (with permissions set accordingly) but then, on a second CI run, GitHub Actions would be running with a different UID, causing everything to fail. This change removes all that, simplifying things.

This change also captures STDOUT for all Docker run failures, to aid in any future debugging of similar issues.
