### PR TITLE
0002: Ensure that benchmark errors get reported

### DIFF
--- a/fhir-bench-orchestrator/tests/basics.rs
+++ b/fhir-bench-orchestrator/tests/basics.rs
@@ -22,7 +22,9 @@ fn benchmark_small() {
         .env(ENV_KEY_CONCURRENCY_LEVELS, "1,2")
         .env(ENV_KEY_POPULATION_SIZE, "10")
         .timeout(std::time::Duration::from_secs(60 * 5))
-        .unwrap();
+        .ok();
+    assert!(output.is_ok(), "Failed to run benchmark: '{}'", output.unwrap_err());
+    let output = output.unwrap();
 
     // We want to validate the output from STDOUT and STDERR, so we capture them to `str`s, here.
     let stderr = String::from_utf8_lossy(&output.stderr);

--- a/fhir-bench-orchestrator/tests/basics.rs
+++ b/fhir-bench-orchestrator/tests/basics.rs
@@ -23,7 +23,11 @@ fn benchmark_small() {
         .env(ENV_KEY_POPULATION_SIZE, "10")
         .timeout(std::time::Duration::from_secs(60 * 5))
         .ok();
-    assert!(output.is_ok(), "Failed to run benchmark: '{}'", output.unwrap_err());
+    assert!(
+        output.is_ok(),
+        "Failed to run benchmark: '{}'",
+        output.unwrap_err()
+    );
     let output = output.unwrap();
 
     // We want to validate the output from STDOUT and STDERR, so we capture them to `str`s, here.


### PR DESCRIPTION
I've noticed it's not always clear why the ITs failed. Just trying to add some more detail around that.
