### PR TITLE
0003: Fix CI Error with target Directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,6 +673,7 @@ dependencies = [
  "slog-stdlog",
  "slog-term",
  "slog_derive",
+ "tempfile",
  "thiserror",
  "url",
 ]

--- a/fhir-bench-orchestrator/Cargo.toml
+++ b/fhir-bench-orchestrator/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "fhir-bench-orchestrator"
 version = "0.1.0"
+resolver = "2"
 authors = ["Karl M. Davis <karl@justdavis.com>"]
 edition = "2018"
 
@@ -57,5 +58,11 @@ hdrhistogram = "7"
 base64 = "0.13"
 flate2 = "1.0"
 
+
+[dev-dependencies]
+
 # Used in integration tests, to run binaries and verify results.
 assert_cmd = "1"
+
+# Used in tests, to generate random temp dirs.
+tempfile = "3"

--- a/fhir-bench-orchestrator/src/config.rs
+++ b/fhir-bench-orchestrator/src/config.rs
@@ -89,33 +89,37 @@ impl AppConfig {
 
     /// Returns the root directory for the benchmarks project; the Git repo's top-level directory.
     pub fn benchmark_dir(&self) -> Result<PathBuf> {
-        // For now, this is hard-coded to check a couple of likely scenarios:
-        //
-        // 1. Someone is running from the `fhir-bench-orchestrator` module, like might happen if they are
-        //    running a specific test from their IDE.
-        // 2. Someone is running from the Git project's root directory, like they might from a terminal.
-        let current_dir =
-            std::env::current_dir().context("unable to retrieve current directory")?;
+        benchmark_dir()
+    }
+}
 
-        if current_dir
-            .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            == Some("fhir-bench-orchestrator".to_string())
-        {
-            Ok(current_dir
-                .parent()
-                .expect("Unable to get module parent directory.")
-                .into())
-        } else if current_dir
-            .read_dir()?
-            .any(|e| e.is_ok() && e.as_ref().unwrap().file_name() == ".git")
-        {
-            Ok(current_dir)
-        } else {
-            Err(anyhow!(
-                "Unable to find benchmark directory from current directory: '{:?}'",
-                current_dir
-            ))
-        }
+/// Returns the root directory for the benchmarks project; the Git repo's top-level directory.
+pub fn benchmark_dir() -> Result<PathBuf> {
+    // For now, this is hard-coded to check a couple of likely scenarios:
+    //
+    // 1. Someone is running from the `fhir-bench-orchestrator` module, like might happen if they are
+    //    running a specific test from their IDE.
+    // 2. Someone is running from the Git project's root directory, like they might from a terminal.
+    let current_dir = std::env::current_dir().context("unable to retrieve current directory")?;
+
+    if current_dir
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        == Some("fhir-bench-orchestrator".to_string())
+    {
+        Ok(current_dir
+            .parent()
+            .expect("Unable to get module parent directory.")
+            .into())
+    } else if current_dir
+        .read_dir()?
+        .any(|e| e.is_ok() && e.as_ref().unwrap().file_name() == ".git")
+    {
+        Ok(current_dir)
+    } else {
+        Err(anyhow!(
+            "Unable to find benchmark directory from current directory: '{:?}'",
+            current_dir
+        ))
     }
 }

--- a/fhir-bench-orchestrator/src/lib.rs
+++ b/fhir-bench-orchestrator/src/lib.rs
@@ -143,7 +143,7 @@ fn create_app_state() -> Result<AppState> {
     let server_plugins: Vec<Arc<dyn ServerPlugin>> = servers::create_server_plugins()?;
 
     // Setup all global/shared resources.
-    let sample_data = sample_data::generate_data(&logger, &config)
+    let sample_data = sample_data::generate_data_using_config(&logger, &config)
         .context("Error when generating sample data.")?;
 
     Ok(AppState {

--- a/fhir-bench-orchestrator/src/sample_data.rs
+++ b/fhir-bench-orchestrator/src/sample_data.rs
@@ -352,12 +352,20 @@ fn find_sample_data(data_dir: PathBuf) -> Result<SampleData> {
 
         if file_name.starts_with("hospitalInformation") {
             if hospitals.is_some() {
-                return Err(anyhow!("multiple hospitalInformation files"));
+                return Err(anyhow!(
+                    "multiple hospitalInformation files: '{:?}' and '{:?}'",
+                    file,
+                    hospitals
+                ));
             }
             hospitals = Some(file.path());
         } else if file_name.starts_with("practitionerInformation") {
             if practitioners.is_some() {
-                return Err(anyhow!("multiple practitionerInformation files"));
+                return Err(anyhow!(
+                    "multiple practitionerInformation files: '{:?}' and '{:?}'",
+                    file,
+                    practitioners
+                ));
             }
             practitioners = Some(file.path());
         } else if file_name == "config.json" {

--- a/synthetic-data/generate-synthetic-data.sh
+++ b/synthetic-data/generate-synthetic-data.sh
@@ -40,9 +40,8 @@ docker build --file ./Dockerfile.synthea -t "${IMAGE_TAG}" --cache-from docker.p
 
 # Run Synthea, with the specified options.
 target="$(pwd)/target"
-ls -la
+ls -la 1>&2
 if [[ ! -d "${target}" ]]; then mkdir "${target}"; fi
-ls -la
 docker run \
   --rm \
   --mount source="${target}",target="/synthea/target/",type=bind \

--- a/synthetic-data/generate-synthetic-data.sh
+++ b/synthetic-data/generate-synthetic-data.sh
@@ -11,7 +11,7 @@ SEED=42
 
 # Use GNU getopt to parse the options passed to this script.
 TEMP=`getopt \
-	p: \
+	p:t: \
 	$*`
 if [ $? != 0 ] ; then echo "Terminating." >&2 ; exit 1 ; fi
 
@@ -24,6 +24,8 @@ while true; do
 	case "$1" in
 		-p )
 			populationSize="$2"; shift 2 ;;
+		-t )
+			targetDirectory="$2"; shift 2 ;;
 		-- ) shift; break ;;
 		* ) break ;;
 	esac
@@ -31,6 +33,10 @@ done
 
 # Verify that all required options were specified.
 if [[ -z "${populationSize}" ]]; then >&2 echo 'The -p option for desired population size is required.'; exit 1; fi
+if [[ -z "${targetDirectory}" ]]; then >&2 echo 'The -t option for the target directory is required.'; exit 1; fi
+
+# Create the target directory, if needed.
+if [[ ! -d "${targetDirectory}" ]]; then mkdir "${targetDirectory}"; fi
 
 # This setting enables proper `docker build` caching, which is particularly important for CI systems.
 export DOCKER_BUILDKIT=1
@@ -39,19 +45,16 @@ export DOCKER_BUILDKIT=1
 docker build --file ./Dockerfile.synthea -t "${IMAGE_TAG}" --cache-from docker.pkg.github.com/karlmdavis/fhir-benchmarks/synthea --build-arg BUILDKIT_INLINE_CACHE=1 .
 
 # Run Synthea, with the specified options.
-target="$(pwd)/target"
-ls -la 1>&2
-if [[ ! -d "${target}" ]]; then mkdir "${target}"; fi
 docker run \
   --rm \
-  --mount source="${target}",target="/synthea/target/",type=bind \
+  --mount source="${targetDirectory}",target="/synthea/target/",type=bind \
   --user "$(id -u)" \
   --entrypoint '/bin/bash' \
   "${IMAGE_TAG}" \
   -x -c 'id && ls -lan / && ls -lan /synthea'
 docker run \
   --rm \
-  --mount source="${target}",target="/synthea/target/",type=bind \
+  --mount source="${targetDirectory}",target="/synthea/target/",type=bind \
   --user "$(id -u)" \
   "${IMAGE_TAG}" \
   -s "${SEED}" \

--- a/synthetic-data/generate-synthetic-data.sh
+++ b/synthetic-data/generate-synthetic-data.sh
@@ -40,7 +40,9 @@ docker build --file ./Dockerfile.synthea -t "${IMAGE_TAG}" --cache-from docker.p
 
 # Run Synthea, with the specified options.
 target="$(pwd)/target"
+ls -la
 if [[ ! -d "${target}" ]]; then mkdir "${target}"; fi
+ls -la
 docker run \
   --rm \
   --mount source="${target}",target="/synthea/target/",type=bind \


### PR DESCRIPTION
Trying to resolve this build failure: <https://github.com/karlmdavis/fhir-benchmarks/runs/2472529746?check_suite_focus=true>.

Turns out that `cargo test` command runs tests in parallel, and so we had two instances of Synthea running against the same output directory, which was causing intermittent weirdness in the tests.

Refactored the tests so that they could run Synthea against a random target directory, which fixed the issue.