### PR TITLE
0002: Resolve Cargo warning about resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
     "fhir-bench-orchestrator",

--- a/fhir-bench-orchestrator/Cargo.toml
+++ b/fhir-bench-orchestrator/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "fhir-bench-orchestrator"
 version = "0.1.0"
-resolver = "2"
 build = "build.rs"
 authors = ["Karl M. Davis <karl@justdavis.com>"]
 edition = "2018"


### PR DESCRIPTION
Had it in the wrong Cargo.toml file, per <https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions>.

Was giving me this warning:

```
warning: resolver for the non root package will be ignored, specify resolver at the workspace root:
Warning: package: /home/runner/work/fhir-benchmarks/fhir-benchmarks/fhir-bench-orchestrator/Cargo.toml
workspace: /home/runner/work/fhir-benchmarks/fhir-benchmarks/Cargo.toml
```
