### PR TITLE
Document SSL headers dependency on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ First, ensure you have installed the following prerequisites:
 * [Rust](https://www.rust-lang.org/) >= v1.51.0, as installed via [rustup](https://www.rust-lang.org/learn/get-started).
 * [Docker](https://www.docker.com/) >= v20.10.6
 * [Docker Compose](https://docs.docker.com/compose/) >= v1.27.4
+* (Ubuntu only) install `libssl-dev`
 
 Then, run these commands to clone, build, and run the benchmark suite's tests:
 


### PR DESCRIPTION
```
error: failed to run custom build command for `openssl-sys v0.9.62`

Caused by:
  process didn't exit successfully: `/media/vadi/SSDer/Programs/fhir-benchmarks/target/debug/build/openssl-sys-3fb7869ab0e58896/build-script-main` (exit code: 101)
  --- stdout
  cargo:rustc-cfg=const_fn
  cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR
  X86_64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_LIB_DIR
  OPENSSL_LIB_DIR unset
  cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR
  X86_64_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_INCLUDE_DIR
  OPENSSL_INCLUDE_DIR unset
  cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_DIR
  X86_64_UNKNOWN_LINUX_GNU_OPENSSL_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_DIR
  OPENSSL_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=OPENSSL_STATIC
  cargo:rerun-if-env-changed=OPENSSL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
  run pkg_config fail: "`\"pkg-config\" \"--libs\" \"--cflags\" \"openssl\"` did not exit successfully: exit code: 1\n--- stderr\nPackage openssl was not found in the pkg-config search path.\nPerhaps you should add the directory containing `openssl.pc\'\nto the PKG_CONFIG_PATH environment variable\nNo package \'openssl\' found\n"

  --- stderr
  thread 'main' panicked at '

  Could not find directory of OpenSSL installation, and this `-sys` crate cannot
  proceed without this knowledge. If OpenSSL is installed and this crate had
  trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the
  compilation process.

  Make sure you also have the development packages of openssl installed.
  For example, `libssl-dev` on Ubuntu or `openssl-devel` on Fedora.

  If you're in a situation where you think the directory *should* be found
  automatically, please open a bug at https://github.com/sfackler/rust-openssl
  and include information about your system as well as this message.

  $HOST = x86_64-unknown-linux-gnu
  $TARGET = x86_64-unknown-linux-gnu
  openssl-sys = 0.9.62

  ', /home/vadi/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-sys-0.9.62/build/find_normal.rs:174:5
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
error: build failed

fhir-benchmarks on  main via 🦀 v1.52.1 took 42s 
✦ ❯ sudo apt install libssl-dev
[sudo] password for vadi: 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Suggested packages:
  libssl-doc
The following NEW packages will be installed:
  libssl-dev
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 1,582 kB of archives.
After this operation, 8,006 kB of additional disk space will be used.
Get:1 http://nl.archive.ubuntu.com/ubuntu focal-updates/main amd64 libssl-dev amd64 1.1.1f-1ubuntu2.3 [1,582 kB]
Fetched 1,582 kB in 0s (4,379 kB/s)  
Selecting previously unselected package libssl-dev:amd64.
(Reading database ... 279587 files and directories currently installed.)
Preparing to unpack .../libssl-dev_1.1.1f-1ubuntu2.3_amd64.deb ...
Unpacking libssl-dev:amd64 (1.1.1f-1ubuntu2.3) ...
Setting up libssl-dev:amd64 (1.1.1f-1ubuntu2.3) ...

fhir-benchmarks on  main via 🦀 v1.52.1 took 4s 
✦ ❯ cargo test
   Compiling ctor v0.1.20
   Compiling serde_derive v1.0.125
   Compiling futures-macro v0.3.14
   Compiling thiserror-impl v1.0.24
   Compiling time-macros-impl v0.1.1
   Compiling pin-project-internal v1.0.7
   Compiling enum-iterator-derive v0.6.0
   Compiling async-attributes v1.1.2
   Compiling async-trait v0.1.50
   Compiling slog_derive v0.2.0
   Compiling openssl-sys v0.9.62
   Compiling getset v0.1.1
   Compiling hdrhistogram v7.2.0
   Compiling vergen v5.1.5
   Compiling openssl v0.10.34
   Compiling native-tls v0.2.7
   Compiling libgit2-sys v0.12.19+1.1.0
   Compiling enum-iterator v0.6.0
   Compiling sysinfo v0.17.2
   Compiling value-bag v1.0.0-alpha.6
   Compiling time-macros v0.1.1
   Compiling git2 v0.13.18
   Compiling time v0.2.26
   Compiling futures-util v0.3.14
   Compiling log v0.4.14
   Compiling mio v0.7.11
   Compiling polling v2.0.3
   Compiling kv-log-macro v1.0.7
   Compiling want v0.3.0
   Compiling thiserror v1.0.24
   Compiling cookie v0.14.4
   Compiling async-io v1.4.1
   Compiling pin-project v1.0.7
   Compiling tokio v1.5.0
   Compiling async-global-executor v2.0.2
   Compiling async-std v1.9.0
   Compiling futures-executor v0.3.14
   Compiling futures v0.3.14
   Compiling fhir-bench-orchestrator v0.1.0 (/media/vadi/SSDer/Programs/fhir-benchmarks/fhir-bench-orchestrator)
   Compiling serde v1.0.125
   Compiling tokio-util v0.6.6
   Compiling tokio-native-tls v0.3.0
   Compiling h2 v0.3.3
   Compiling erased-serde v0.3.13
   Compiling url v2.2.1
   Compiling serde_json v1.0.64
   Compiling serde_urlencoded v0.7.0
   Compiling serde_qs v0.7.2
   Compiling chrono v0.4.19
   Compiling rust_decimal v1.12.3
   Compiling slog v2.7.0
   Compiling slog-scope v4.4.0
   Compiling slog-async v2.6.0
   Compiling slog-term v2.8.0
   Compiling slog-stdlog v4.1.0
   Compiling http-types v2.11.0
   Compiling slog-json v2.3.0
   Compiling hyper v0.14.7
   Compiling async-h1 v2.3.2
   Compiling hyper-tls v0.5.0
   Compiling reqwest v0.11.3
    Finished test [unoptimized + debuginfo] target(s) in 17.80s
     Running unittests (target/debug/deps/fhir_bench_orchestrator-fdedba08755bea24)

running 13 tests
```