### PR TITLE
0013: Make Docker Compose Setup More Consistent

### DIFF
--- a/.github/workflows/rust_basics.yml
+++ b/.github/workflows/rust_basics.yml
@@ -94,17 +94,6 @@ jobs:
           login-server: docker.pkg.github.com
           username: karlmdavis
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run Docker Build - hapi_fhir_jpaserver
-        env:
-          DOCKER_BUILDKIT: 1
-        run: |
-          echo 'docker pull'
-          docker pull docker.pkg.github.com/karlmdavis/fhir-benchmarks/hapi-fhir-jpaserver-start || true
-          echo 'docker build'
-          docker build -t docker.pkg.github.com/karlmdavis/fhir-benchmarks/hapi-fhir-jpaserver-start --cache-from docker.pkg.github.com/karlmdavis/fhir-benchmarks/hapi-fhir-jpaserver-start --build-arg BUILDKIT_INLINE_CACHE=1 .
-          echo 'docker push'
-          docker push docker.pkg.github.com/karlmdavis/fhir-benchmarks/hapi-fhir-jpaserver-start
-        working-directory: ./server_builds/hapi_fhir_jpaserver/
       - name: Run Docker Build - synthea
         env:
           DOCKER_BUILDKIT: 1

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "server_builds_hapi_fhir_jpaserver"]
-	path = server_builds/hapi_fhir_jpaserver
-	url = https://github.com/karlmdavis/hapi-fhir-jpaserver-starter.git
-	branch = fhir-benchmarks
 [submodule "fhir-bench-site/sass_modules/bulma"]
 	path = fhir-bench-site/sass_modules/bulma
 	url = https://github.com/jgthms/bulma.git

--- a/fhir-bench-orchestrator/src/servers/firely_spark.rs
+++ b/fhir-bench-orchestrator/src/servers/firely_spark.rs
@@ -120,7 +120,7 @@ fn server_work_dir(benchmark_dir: &Path) -> PathBuf {
 /// Returns an empty [Result], where an error indicates that the server was not ready.
 #[tracing::instrument(level = "debug", fields(server_name = SERVER_NAME), skip(app_state, server_handle))]
 async fn wait_for_ready(app_state: &AppState, server_handle: &dyn ServerHandle) -> Result<()> {
-    tokio::time::timeout(std::time::Duration::from_secs(60), async {
+    tokio::time::timeout(std::time::Duration::from_secs(60 * 5), async {
         let mut ready = false;
         let mut probe = None;
 

--- a/fhir-bench-orchestrator/src/servers/hapi_jpa.rs
+++ b/fhir-bench-orchestrator/src/servers/hapi_jpa.rs
@@ -35,22 +35,17 @@ impl ServerPlugin for HapiJpaFhirServerPlugin {
         let server_work_dir = server_work_dir(&app_state.config.benchmark_dir()?);
 
         /*
-         * Build and launch our submodule'd fork of the sample JPA server.
-         *
-         * Note: The environment variables used here are required to get build caching working correctly,
-         * particularly for CI machines where the cache would otherwise be cold.
+         * Build and launch the server.
          */
-        let docker_up_output = Command::new("docker-compose")
+        let docker_up_output = Command::new("./docker_compose_hapi_jpaserver_starter.sh")
             .args(&["up", "--detach"])
-            .env("COMPOSE_DOCKER_CLI_BUILD", "1")
-            .env("DOCKER_BUILDKIT", "1")
             .current_dir(&server_work_dir)
             .output()
-            .context("Failed to run 'docker-compose up'.")?;
+            .context("Failed to run 'docker_compose_hapi_jpaserver_starter.sh'.")?;
         if !docker_up_output.status.success() {
             return Err(eyre!(crate::errors::AppError::ChildProcessFailure(
                 docker_up_output.status,
-                "Failed to launch HAPI FHIR JPA Server via docker-compose.".to_owned(),
+                format!("Failed to launch {} via Docker Compose.", SERVER_NAME),
                 String::from_utf8_lossy(&docker_up_output.stdout).into(),
                 String::from_utf8_lossy(&docker_up_output.stderr).into()
             )));
@@ -85,7 +80,7 @@ impl ServerPlugin for HapiJpaFhirServerPlugin {
 fn server_work_dir(benchmark_dir: &Path) -> PathBuf {
     benchmark_dir
         .join("server_builds")
-        .join("hapi_fhir_jpaserver")
+        .join("hapi_jpaserver_starter")
 }
 
 /// Checks the specified server repeatedly to see if it is ready, up to a hardcoded timeout.
@@ -138,7 +133,7 @@ impl ServerHandle for HapiJpaFhirServerHandle {
     }
 
     fn base_url(&self) -> url::Url {
-        Url::parse("http://localhost:8080/hapi-fhir-jpaserver/fhir/").expect("Unable to parse URL.")
+        Url::parse("http://localhost:8080/fhir/").expect("Unable to parse URL.")
     }
 
     fn client(&self) -> Result<reqwest::Client> {
@@ -146,7 +141,7 @@ impl ServerHandle for HapiJpaFhirServerHandle {
     }
 
     fn emit_logs(&self) -> Result<String> {
-        match Command::new("docker-compose")
+        match Command::new("./docker_compose_hapi_jpaserver_starter.sh")
             .args(&["logs", "--no-color"])
             .current_dir(&self.server_work_dir)
             .output()
@@ -197,7 +192,7 @@ impl ServerHandle for HapiJpaFhirServerHandle {
 
     #[tracing::instrument(level = "debug", fields(server_name = SERVER_NAME), skip(self))]
     fn shutdown(&self) -> Result<()> {
-        let docker_down_output = Command::new("docker-compose")
+        let docker_down_output = Command::new("./docker_compose_hapi_jpaserver_starter.sh")
             .args(&["down"])
             .current_dir(&self.server_work_dir)
             .output()

--- a/fhir-bench-orchestrator/src/servers/hapi_jpa.rs
+++ b/fhir-bench-orchestrator/src/servers/hapi_jpa.rs
@@ -92,7 +92,7 @@ fn server_work_dir(benchmark_dir: &Path) -> PathBuf {
 /// Returns an empty [Result], where an error indicates that the server was not ready.
 #[tracing::instrument(level = "debug", fields(server_name = SERVER_NAME), skip(app_state, server_handle))]
 async fn wait_for_ready(app_state: &AppState, server_handle: &dyn ServerHandle) -> Result<()> {
-    tokio::time::timeout(std::time::Duration::from_secs(60), async {
+    tokio::time::timeout(std::time::Duration::from_secs(60 * 5), async {
         let mut ready = false;
         let mut probe = None;
 

--- a/fhir-bench-orchestrator/src/servers/ibm_fhir.rs
+++ b/fhir-bench-orchestrator/src/servers/ibm_fhir.rs
@@ -103,7 +103,7 @@ fn server_work_dir(benchmark_dir: &Path) -> PathBuf {
 /// Returns an empty [Result], where an error indicates that the server was not ready.
 #[tracing::instrument(level = "debug", fields(server_name = SERVER_NAME), skip(app_state, server_handle))]
 async fn wait_for_ready(app_state: &AppState, server_handle: &dyn ServerHandle) -> Result<()> {
-    tokio::time::timeout(std::time::Duration::from_secs(60), async {
+    tokio::time::timeout(std::time::Duration::from_secs(60 * 5), async {
         let mut ready = false;
         let mut probe = None;
 

--- a/fhir-bench-orchestrator/src/servers/ibm_fhir.rs
+++ b/fhir-bench-orchestrator/src/servers/ibm_fhir.rs
@@ -55,11 +55,11 @@ async fn launch_server(app_state: &AppState) -> Result<Box<dyn ServerHandle>> {
         .args(&["up", "--detach"])
         .current_dir(&server_work_dir)
         .output()
-        .context("Failed to run 'ibm_fhir_launch.sh'.")?;
+        .context("Failed to run 'docker_compose_ibm_fhir.sh'.")?;
     if !docker_up_output.status.success() {
         return Err(eyre!(crate::errors::AppError::ChildProcessFailure(
             docker_up_output.status,
-            "Failed to launch IBM FHIR Server.".to_owned(),
+            format!("Failed to launch {} via Docker Compose.", SERVER_NAME),
             String::from_utf8_lossy(&docker_up_output.stdout).into(),
             String::from_utf8_lossy(&docker_up_output.stderr).into()
         )));

--- a/fhir-bench-orchestrator/tests/basics.rs
+++ b/fhir-bench-orchestrator/tests/basics.rs
@@ -21,7 +21,7 @@ fn benchmark_small() {
         .env(ENV_KEY_ITERATIONS, "2")
         .env(ENV_KEY_CONCURRENCY_LEVELS, "1,2")
         .env(ENV_KEY_POPULATION_SIZE, "10")
-        .timeout(std::time::Duration::from_secs(60 * 5))
+        .timeout(std::time::Duration::from_secs(60 * 15))
         .ok();
     assert!(
         output.is_ok(),

--- a/server_builds/firely_spark/docker_compose_firely_spark.sh
+++ b/server_builds/firely_spark/docker_compose_firely_spark.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+# Specify the version of the Spark server to use.
+version="v1.5.10-r4"  # Published 2021-10-19.
+
+# Grab the directory that this script lives in.
+scriptDirectory="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Download the resources required to run the server via Docker Compose.
+curl -L -s -S \
+  "https://github.com/FirelyTeam/spark/raw/${version}/.docker/docker-compose.example.yml" \
+  > "${scriptDirectory}/docker-compose.yml"
+
+# Replace the 'r4-latest' tag with the desired version.
+#
+# Note: right now, the Spark `.docker/docker-compose.example.yml` file always points to the `r4-latest`
+# Docker image, and so needs to be edited to ensure that our benchmarks are running against a stable target.
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed \
+    -i '' \
+    -e "s/spark:r4-latest/spark:${version}/g" \
+    "${scriptDirectory}/docker-compose.yml"
+  sed \
+    -i '' \
+    -e "s/mongo:r4-latest/mongo:${version}/g" \
+    "${scriptDirectory}/docker-compose.yml"
+else
+  sed \
+    -i \
+    -e "s/spark:r4-latest/spark:${version}/g" \
+    "${scriptDirectory}/docker-compose.yml"
+  sed \
+    -i \
+    -e "s/mongo:r4-latest/mongo:${version}/g" \
+    "${scriptDirectory}/docker-compose.yml"
+fi
+
+# Run whatever docker-compose command was specified against the downloaded docker-compose.yml file.
+docker-compose \
+  --file "${scriptDirectory}/docker-compose.yml" \
+  "$@"

--- a/server_builds/firely_spark/spark_download_and_launch.sh
+++ b/server_builds/firely_spark/spark_download_and_launch.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -e
-set -o pipefail
-
-curl \
-  'https://raw.githubusercontent.com/FirelyTeam/spark/r4/master/.docker/docker-compose.example.yml' \
-  > docker-compose.yml
-docker-compose up

--- a/server_builds/hapi_jpaserver_starter/docker-compose.yml
+++ b/server_builds/hapi_jpaserver_starter/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3"
+services:
+  hapi-fhir-jpaserver-start:
+    image: "hapiproject/hapi:v5.5.2-distroless"  # Published 2021-11-11.
+    restart: on-failure
+    ports:
+      - "8080:8080"
+    volumes:
+      - hapi-data:/data/hapi
+    volumes:
+      - type: bind
+        source: ./hapi-data
+        target: /data/hapi
+        read_only: true
+    environment:
+      SPRING_CONFIG_LOCATION: 'file:///data/hapi/application.yaml'
+    depends_on:
+      - "hapi-fhir-mysql"
+  hapi-fhir-mysql:
+    image: mysql:8.0.27  # Published 2021-10-18.
+    container_name: hapi-fhir-mysql
+    #https://dev.mysql.com/doc/refman/8.0/en/identifier-case-sensitivity.html
+    command: --lower_case_table_names=1
+    restart: always
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_DATABASE: 'hapi'
+      MYSQL_USER: 'admin'
+      MYSQL_PASSWORD: 'admin'
+      MYSQL_ROOT_PASSWORD: 'admin'

--- a/server_builds/hapi_jpaserver_starter/docker_compose_hapi_jpaserver_starter.sh
+++ b/server_builds/hapi_jpaserver_starter/docker_compose_hapi_jpaserver_starter.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+# Grab the directory that this script lives in.
+scriptDirectory="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Run whatever docker-compose command was specified against the downloaded docker-compose.yml file.
+docker-compose \
+  --file "${scriptDirectory}/docker-compose.yml" \
+  "$@"

--- a/server_builds/hapi_jpaserver_starter/hapi-data/application.yaml
+++ b/server_builds/hapi_jpaserver_starter/hapi-data/application.yaml
@@ -1,0 +1,167 @@
+spring:
+  datasource:
+    #url: 'jdbc:h2:file:./target/database/h2'
+    ##url: jdbc:h2:mem:test_mem
+    #username: sa
+    #password: null
+    #driverClassName: org.h2.Driver
+    #max-active: 15
+    url: 'jdbc:mysql://hapi-fhir-mysql:3306/hapi'
+    username: admin
+    password: admin
+    driverClassName: com.mysql.jdbc.Driver
+
+    # database connection pool size
+    hikari:
+      maximum-pool-size: 10
+  jpa:
+    properties:
+      hibernate.format_sql: false
+      hibernate.show_sql: false
+#      hibernate.dialect: org.hibernate.dialect.h2dialect
+#      hibernate.hbm2ddl.auto: update
+#      hibernate.jdbc.batch_size: 20
+#      hibernate.cache.use_query_cache: false
+#      hibernate.cache.use_second_level_cache: false
+#      hibernate.cache.use_structured_entries: false
+#      hibernate.cache.use_minimal_puts: false
+###    These settings will enable fulltext search with lucene
+#      hibernate.search.enabled: true
+#      hibernate.search.backend.type: lucene
+#      hibernate.search.backend.analysis.configurer: ca.uhn.fhir.jpa.search.HapiLuceneAnalysisConfigurer
+#      hibernate.search.backend.directory.type: local-filesystem
+#      hibernate.search.backend.directory.root: target/lucenefiles
+#      hibernate.search.backend.lucene_version: lucene_current
+  batch:
+    job:
+      enabled: false
+  main:
+#    TODO 5.6.0 -> Prevent duplicate bean definitions in the Spring batch config in HAPI: see:
+    allow-bean-definition-overriding: true
+hapi:
+  fhir:
+    ### This enables the swagger-ui at /fhir/swagger-ui/index.html as well as the /fhir/api-docs (see https://hapifhir.io/hapi-fhir/docs/server_plain/openapi.html)
+    openapi_enabled: true
+    ### This is the FHIR version. Choose between, DSTU2, DSTU3, R4 or R5
+    fhir_version: R4
+### enable to use the ApacheProxyAddressStrategy which uses X-Forwarded-* headers
+### to determine the FHIR server address
+#   use_apache_address_strategy: false
+### forces the use of the https:// protocol for the returned server address.
+### alternatively, it may be set using the X-Forwarded-Proto header.
+#   use_apache_address_strategy_https: false
+### enable to set the Server URL
+#    server_address: http://hapi.fhir.org/baseR4
+#    defer_indexing_for_codesystems_of_size: 101
+#    install_transitive_ig_dependencies: true
+#    implementationguides:
+###    example from registry (packages.fhir.org)
+#      swiss:
+#        name: swiss.mednet.fhir
+#        version: 0.8.0
+#      example not from registry
+#      ips_1_0_0:
+#        url: https://build.fhir.org/ig/HL7/fhir-ips/package.tgz
+#        name: hl7.fhir.uv.ips
+#        version: 1.0.0
+#    supported_resource_types:
+#      - Patient
+#      - Observation
+#    allow_cascading_deletes: true
+#    allow_contains_searches: true
+#    allow_external_references: true
+#    allow_multiple_delete: true
+#    allow_override_default_search_params: true
+#    auto_create_placeholder_reference_targets: false
+#    cql_enabled: true
+#    default_encoding: JSON
+#    default_pretty_print: true
+#    default_page_size: 20
+#    delete_expunge_enabled: true
+#    enable_repository_validating_interceptor: false
+#    enable_index_missing_fields: false
+#    enable_index_contained_resource: false
+#    enforce_referential_integrity_on_delete: false
+#    enforce_referential_integrity_on_write: false
+#    etag_support_enabled: true
+#    expunge_enabled: true
+#    daoconfig_client_id_strategy: null
+#    client_id_strategy: ALPHANUMERIC
+#    fhirpath_interceptor_enabled: false
+#    filter_search_enabled: true
+#    graphql_enabled: true
+#    narrative_enabled: true
+#    mdm_enabled: true
+#    partitioning:
+#      allow_references_across_partitions: false
+#      partitioning_include_in_search_hashes: false
+    cors:
+      allow_Credentials: true
+      # These are allowed_origin patterns, see: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#setAllowedOriginPatterns-java.util.List-
+      allowed_origin:
+        - '*'
+
+    # Search coordinator thread pool sizes
+    search-coord-core-pool-size: 20
+    search-coord-max-pool-size: 100
+    search-coord-queue-capacity: 200
+
+#    logger:
+#      error_format: 'ERROR - ${requestVerb} ${requestUrl}'
+#      format: >-
+#        Path[${servletPath}] Source[${requestHeader.x-forwarded-for}]
+#        Operation[${operationType} ${operationName} ${idOrResourceName}]
+#        UA[${requestHeader.user-agent}] Params[${requestParameters}]
+#        ResponseEncoding[${responseEncodingNoDefault}]
+#      log_exceptions: true
+#      name: fhirtest.access
+#    max_binary_size: 104857600
+#    max_page_size: 200
+#    retain_cached_searches_mins: 60
+#    reuse_cached_search_results_millis: 60000
+    tester:
+        home:
+          name: Local Tester
+          server_address: 'http://localhost:8080/fhir'
+          refuse_to_fetch_third_party_urls: false
+          fhir_version: R4
+        global:
+          name: Global Tester
+          server_address: "http://hapi.fhir.org/baseR4"
+          refuse_to_fetch_third_party_urls: false
+          fhir_version: R4
+#    validation:
+#      requests_enabled: true
+#      responses_enabled: true
+#    binary_storage_enabled: true
+#    bulk_export_enabled: true
+#    subscription:
+#      resthook_enabled: true
+#      websocket_enabled: false
+#      email:
+#        from: some@test.com
+#        host: google.com
+#        port:
+#        username:
+#        password:
+#        auth:
+#        startTlsEnable:
+#        startTlsRequired:
+#        quitWait:
+#    lastn_enabled: true
+###  This is configuration for normalized quantity serach level default is 0
+###   0: NORMALIZED_QUANTITY_SEARCH_NOT_SUPPORTED - default
+###   1: NORMALIZED_QUANTITY_STORAGE_SUPPORTED
+###   2: NORMALIZED_QUANTITY_SEARCH_SUPPORTED
+#    normalized_quantity_search_level: 2
+#elasticsearch:
+#  debug:
+#    pretty_print_json_log: false
+#    refresh_after_write: false
+#  enabled: false
+#  password: SomePassword
+#  required_index_status: YELLOW
+#  rest_url: 'localhost:9200'
+#  protocol: 'http'
+#  schema_management_strategy: CREATE
+#  username: SomeUsername

--- a/server_builds/ibm_fhir/docker_compose_ibm_fhir.sh
+++ b/server_builds/ibm_fhir/docker_compose_ibm_fhir.sh
@@ -4,11 +4,7 @@ set -e
 set -o pipefail
 
 # Specify the version of the IBM FHIR server to use.
-#
-# Note: right now, the IBM FHIR `demo/docker-compose.yml` file always points to the `latest` Docker image,
-# so this version will have to be manually kept upto date, lest the Docker container and the Docker Compose
-# configuration for it diverge in incompatible ways.
-version="4.9.2"
+version="4.9.2"  # Published 2021-09-22.
 
 # Grab the directory that this script lives in.
 scriptDirectory="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -21,7 +17,26 @@ if [[ ! -d "${scriptDirectory}/FHIR-${version}" ]]; then
   tar --directory "${scriptDirectory}" -x -z -f "${scriptDirectory}/${version}.tar.gz"
 fi
 
+# Replace the 'latest' tag with the desired version.
+#
+# Note: right now, the IBM FHIR `demo/docker-compose.yml` file always points to the `latest` Docker image,
+# and so needs to be edited to ensure that the Docker container and the Docker Compose configuration for it
+# don't diverge in incompatible ways.
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed \
+    -i '' \
+    -e "s/ibm-fhir-server:latest/ibm-fhir-server:${version}/g" \
+    "${scriptDirectory}/FHIR-${version}/demo/docker-compose.yml"
+else
+  sed \
+    -i \
+    -e "s/ibm-fhir-server:latest/ibm-fhir-server:${version}/g" \
+    "${scriptDirectory}/FHIR-${version}/demo/docker-compose.yml"
+fi
+
 # Run whatever docker-compose command was specified against the downloaded docker-compose.yml file.
 COMPOSE_DOCKER_CLI_BUILD=1 \
   DOCKER_BUILDKIT=1 \
-  docker-compose --file "${scriptDirectory}/FHIR-${version}/demo/docker-compose.yml" "$@"
+  docker-compose \
+  --file "${scriptDirectory}/FHIR-${version}/demo/docker-compose.yml" \
+  "$@"


### PR DESCRIPTION
This formalizes the pattern of wrapping the `docker compose` command for each supported FHIR server with a shell script that handles any of the customizations required.

Should make dealing with the servers a lot simpler, with them all following the same pattern.

I hope it will also allow future changes that remove a lot of the `ServerPlugin` and `ServerHandle` code, in favor of a common implementation.

This is part of the work on [User Story 13: Improve Management of FHIR Server Dockerfiles](../blob/main/dev/stories/0013-refactor-dockerfiles.md).
