### PR TITLE
0015: Enable Tracing for Tests

### DIFF
--- a/.github/workflows/rust_basics.yml
+++ b/.github/workflows/rust_basics.yml
@@ -110,6 +110,8 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+        env:
+          RUST_BACKTRACE: full
 
   lints:
     name: Lints

--- a/.github/workflows/rust_basics.yml
+++ b/.github/workflows/rust_basics.yml
@@ -112,6 +112,8 @@ jobs:
           command: test
         env:
           RUST_BACKTRACE: full
+          RUST_LOG: info
+          RUST_LOG_SPAN_EVENTS: new,close
 
   lints:
     name: Lints

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tempfile",
+ "test-env-log",
  "thiserror",
  "tokio",
  "tracing",
@@ -1489,6 +1490,17 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "test-env-log"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3e4b132a630cc8a0d06cfcb400da67adef3d0087a94b3332d4692908f0c2544"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/dev/plans/0001-round-1.md
+++ b/dev/plans/0001-round-1.md
@@ -38,7 +38,7 @@ The following user stories are currently planned to be in scope for this release
 * [x] [IBM FHIR](../stories/0012-ibm-fhir.md)
 * [ ] [Improve Management of FHIR Server Dockerfiles](../stories/0013-refactor-dockerfiles.md)
 * [ ] [Cache Sample Data in S3](../stories/0014-cache-sample-data-in-s3.md)
-* [ ] [Tracing](../stories/0015-tracing.md)
+* [x] [Tracing](../stories/0015-tracing.md)
 * [ ] [Support More `Organization` Operations](../stories/0016-more-organization-operations.md)
 * [ ] [Make it Simpler to Add Benchmark Operations](../stories/0017-simplify-adding-operations.md)
 * [ ] [Analyze Synthea Output](../stories/0018-analyze-synthea-output.md)

--- a/fhir-bench-orchestrator/Cargo.toml
+++ b/fhir-bench-orchestrator/Cargo.toml
@@ -65,6 +65,11 @@ tempfile = "3"
 # Used in tests, to ensure that the shared resources are properly managed.
 serial_test = "0.5"
 
+# Used to initialize tracing/logging in tests.
+test-env-log = { version = "0.2", default-features = false, features = ["trace"] }
+tracing = {version = "0.1", default-features = false}
+tracing-subscriber = {version = "0.3", default-features = false, features = ["env-filter", "fmt"]}
+
 
 [build-dependencies]
 

--- a/fhir-bench-orchestrator/src/sample_data.rs
+++ b/fhir-bench-orchestrator/src/sample_data.rs
@@ -397,7 +397,8 @@ mod tests {
     use std::collections::HashMap;
 
     /// Verifies that [crate::sample_data::generate_data] works as expected.
-    #[tokio::test]
+    #[tracing::instrument(level = "info")]
+    #[test_env_log::test(tokio::test)]
     async fn generate_data() -> Result<()> {
         let benchmark_dir = crate::config::benchmark_dir()?;
         let target_dir = tempfile::tempdir()?;
@@ -419,7 +420,8 @@ mod tests {
     }
 
     /// Verifies that [crate::sample_data::SampleData::iter_orgs] works as expected.
-    #[tokio::test]
+    #[tracing::instrument(level = "info")]
+    #[test_env_log::test(tokio::test)]
     async fn iter_orgs() -> Result<()> {
         let benchmark_dir = crate::config::benchmark_dir()?;
         let target_dir = tempfile::tempdir()?;

--- a/fhir-bench-orchestrator/src/servers/firely_spark.rs
+++ b/fhir-bench-orchestrator/src/servers/firely_spark.rs
@@ -217,7 +217,8 @@ mod tests {
 
     use eyre::{eyre, Result};
 
-    #[tokio::test]
+    #[tracing::instrument(level = "info")]
+    #[test_env_log::test(tokio::test)]
     #[serial_test::serial(sample_data)]
     async fn verify_server_launch() -> Result<()> {
         let log_target = std::env::temp_dir().join(format!(

--- a/fhir-bench-orchestrator/src/servers/hapi_jpa.rs
+++ b/fhir-bench-orchestrator/src/servers/hapi_jpa.rs
@@ -220,7 +220,8 @@ mod tests {
 
     use eyre::{eyre, Result};
 
-    #[tokio::test]
+    #[tracing::instrument(level = "info")]
+    #[test_env_log::test(tokio::test)]
     #[serial_test::serial(sample_data)]
     async fn verify_server_launch() -> Result<()> {
         let log_target = std::env::temp_dir().join(format!(

--- a/fhir-bench-orchestrator/src/servers/ibm_fhir.rs
+++ b/fhir-bench-orchestrator/src/servers/ibm_fhir.rs
@@ -209,7 +209,8 @@ mod tests {
 
     use eyre::{eyre, Result};
 
-    #[tokio::test]
+    #[tracing::instrument(level = "info")]
+    #[test_env_log::test(tokio::test)]
     #[serial_test::serial(sample_data)]
     async fn verify_server_launch() -> Result<()> {
         let log_target = std::env::temp_dir().join(format!(

--- a/fhir-bench-orchestrator/src/test_framework/mod.rs
+++ b/fhir-bench-orchestrator/src/test_framework/mod.rs
@@ -447,8 +447,9 @@ mod tests {
     static SERVER_OP_NAME_FAKE: &str = "Operation A";
 
     /// Verifies that `FrameworkOperationLog` serializes as expected.
-    #[test]
-    fn serialize_framework_operation_log() {
+    #[tracing::instrument(level = "info")]
+    #[test_env_log::test(tokio::test)]
+    async fn serialize_framework_operation_log() {
         let expected = json!({
             "started": "2020-01-01T13:00:00Z",
             "completed": "2020-01-01T14:00:00Z",
@@ -467,8 +468,9 @@ mod tests {
     }
 
     /// Verifies that `ServerOperationMetrics` serializes as expected.
-    #[test]
-    fn serialize_server_operation_metrics() -> Result<()> {
+    #[tracing::instrument(level = "info")]
+    #[test_env_log::test(tokio::test)]
+    async fn serialize_server_operation_metrics() -> Result<()> {
         let expected = json!({
             "throughput_per_second": 42.0,
             "latency_millis_mean": 1.0,
@@ -499,8 +501,9 @@ mod tests {
     }
 
     /// Verifies that `ServerOperationLog` serializes as expected.
-    #[test]
-    fn serialize_server_operation_log() {
+    #[tracing::instrument(level = "info")]
+    #[test_env_log::test(tokio::test)]
+    async fn serialize_server_operation_log() {
         let expected = json!({
             "operation": "Operation A",
             "errors": [],
@@ -517,8 +520,9 @@ mod tests {
     }
 
     /// Verifies that [ServerOperationMeasurement] serializes as expected.
-    #[test]
-    fn serialize_server_operation_measurement() -> Result<()> {
+    #[tracing::instrument(level = "info")]
+    #[test_env_log::test(tokio::test)]
+    async fn serialize_server_operation_measurement() -> Result<()> {
         let expected = json!({
             "concurrent_users": 10,
             "started": "2020-01-01T15:00:00Z",
@@ -565,8 +569,9 @@ mod tests {
     }
 
     /// Verifies that `FrameworkResults` serializes as expected.
-    #[test]
-    fn serialize_framework_results() -> Result<()> {
+    #[tracing::instrument(level = "info")]
+    #[test_env_log::test(tokio::test)]
+    async fn serialize_framework_results() -> Result<()> {
         let expected = json!({
             "started": "2020-01-01T12:00:00Z",
             "completed": "2020-01-01T19:00:00Z",

--- a/fhir-bench-orchestrator/src/util/serde_duration_iso8601.rs
+++ b/fhir-bench-orchestrator/src/util/serde_duration_iso8601.rs
@@ -73,8 +73,9 @@ mod tests {
     }
 
     /// Verifies that [Duration] values serialize as expected.
-    #[test]
-    fn serialize() {
+    #[tracing::instrument(level = "info")]
+    #[test_env_log::test(tokio::test)]
+    async fn serialize() {
         let expected = json!({
             "duration": "PT1.234S",
         });
@@ -87,8 +88,9 @@ mod tests {
     }
 
     /// Verifies that [Duration] values deserialize as expected.
-    #[test]
-    fn deserialize() {
+    #[tracing::instrument(level = "info")]
+    #[test_env_log::test(tokio::test)]
+    async fn deserialize() {
         let expected = DurationStruct {
             duration: Duration::nanoseconds(super::NANOS_PER_SEC + 234),
         };

--- a/fhir-bench-orchestrator/src/util/serde_duration_millis.rs
+++ b/fhir-bench-orchestrator/src/util/serde_duration_millis.rs
@@ -49,8 +49,9 @@ mod tests {
     }
 
     /// Verifies that [Duration] values serialize as expected.
-    #[test]
-    fn serialize() {
+    #[tracing::instrument(level = "info")]
+    #[test_env_log::test(tokio::test)]
+    async fn serialize() {
         let expected = json!({
             "duration": 1000,
         });
@@ -63,8 +64,9 @@ mod tests {
     }
 
     /// Verifies that [Duration] values deserialize as expected.
-    #[test]
-    fn deserialize() {
+    #[tracing::instrument(level = "info")]
+    #[test_env_log::test(tokio::test)]
+    async fn deserialize() {
         let expected = DurationStruct {
             duration: Duration::milliseconds(1000),
         };

--- a/fhir-bench-orchestrator/src/util/serde_histogram.rs
+++ b/fhir-bench-orchestrator/src/util/serde_histogram.rs
@@ -71,8 +71,9 @@ mod tests {
     }
 
     /// Verifies that [Duration] values serialize as expected.
-    #[test]
-    fn serialize() -> Result<()> {
+    #[tracing::instrument(level = "info")]
+    #[test_env_log::test(tokio::test)]
+    async fn serialize() -> Result<()> {
         let expected = json!({
             "histogram": "HISTFAAAABx4nJNpmSzMwMDAxAABzFCaEUoz2X+AsQA/awKA",
         });
@@ -88,8 +89,9 @@ mod tests {
     }
 
     /// Verifies that [Duration] values deserialize as expected.
-    #[test]
-    fn deserialize() -> Result<()> {
+    #[tracing::instrument(level = "info")]
+    #[test_env_log::test(tokio::test)]
+    async fn deserialize() -> Result<()> {
         let mut expected = DurationStruct {
             histogram: Histogram::<u64>::new(3)?,
         };

--- a/fhir-bench-orchestrator/tests/basics.rs
+++ b/fhir-bench-orchestrator/tests/basics.rs
@@ -11,8 +11,9 @@ use fhir_bench_orchestrator::config::{
 use fhir_bench_orchestrator::test_framework::FrameworkResults;
 
 /// Runs a small version of the benchmarks and verifies the results.
-#[test]
-fn benchmark_small() {
+#[tracing::instrument(level = "info")]
+#[test_env_log::test(tokio::test)]
+async fn benchmark_small() {
     // Launch the benchmark suite, just as it would be from a `cargo run` in the project's top directory.
     let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
     let output = cmd


### PR DESCRIPTION
- Turn on backtraces for `cargo test` in CI.
- Turn on tracing for all tests.

This is part of the work on [User Story 15: Switch to Tracing for Logs](../blob/main/dev/stories/0015-tracing.md).
